### PR TITLE
Added an indefinite cache time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 *.esproj
 *.sublime-workspace
 *.sublime-project
+*.code-workspace
 *.tmproj
 *.tmproject
 .vscode/*

--- a/src/services/backends/DefaultKeyStore.php
+++ b/src/services/backends/DefaultKeyStore.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace weareferal\assetversioner\services\backends;
 
 use Craft;
@@ -7,15 +8,17 @@ use craft\db\Query;
 use weareferal\assetversioner\services\KeyStoreInterface;
 use weareferal\assetversioner\services\KeyStore;
 
-class DefaultKeyStore extends KeyStore implements KeyStoreInterface {
+class DefaultKeyStore extends KeyStore implements KeyStoreInterface
+{
 
-    public function get($key) {
+    public function get($key)
+    {
         $cache = Craft::$app->cache->get("craft_assert_versioner");
         return $cache[$key];
     }
 
-    public function update($versioned_paths) {
+    public function update($versioned_paths)
+    {
         Craft::$app->cache->set("craft_assert_versioner", $versioned_paths);
     }
 }
-?>

--- a/src/services/backends/DefaultKeyStore.php
+++ b/src/services/backends/DefaultKeyStore.php
@@ -19,6 +19,6 @@ class DefaultKeyStore extends KeyStore implements KeyStoreInterface
 
     public function update($versioned_paths)
     {
-        Craft::$app->cache->set("craft_assert_versioner", $versioned_paths);
+        Craft::$app->cache->set("craft_assert_versioner", $versioned_paths, 0);
     }
 }

--- a/src/twigextensions/AssetVersionerTwigExtensions.php
+++ b/src/twigextensions/AssetVersionerTwigExtensions.php
@@ -6,7 +6,8 @@ use Craft;
 
 use weareferal\assetversioner\AssetVersioner;
 
-class AssetVersionerTwigExtensions extends \Twig_Extension {
+class AssetVersionerTwigExtensions extends \Twig_Extension
+{
     public function getName()
     {
         return 'AssetVersioner';
@@ -19,7 +20,8 @@ class AssetVersionerTwigExtensions extends \Twig_Extension {
         ];
     }
 
-    public function getVersion($path) {
+    public function getVersion($path)
+    {
         try {
             $version = AssetVersioner::getInstance()->keystore->get($path);
             if ($version) {
@@ -31,5 +33,3 @@ class AssetVersionerTwigExtensions extends \Twig_Extension {
         return $path;
     }
 }
-
-?>


### PR DESCRIPTION
By default the cache uses Craft's cache defaults which enable a duration to all cached values. This meant the versioned assets were being purged from the cache after a day. This fixed that issue